### PR TITLE
Detect SearchableTrait in parent classes and traits of their traits.

### DIFF
--- a/src/Commands/IndexCommand.php
+++ b/src/Commands/IndexCommand.php
@@ -42,7 +42,7 @@ class IndexCommand extends Command
     {
         $modelClass = $this->argument('model_class');
 
-        if (!in_array(SearchableTrait::class, class_uses($modelClass), true)) {
+        if (!in_array(SearchableTrait::class, class_uses_recursive($modelClass), true)) {
             $this->error('Model not using ' . SearchableTrait::class);
             return;
         }

--- a/src/Commands/UnIndexCommand.php
+++ b/src/Commands/UnIndexCommand.php
@@ -42,7 +42,7 @@ class UnIndexCommand extends Command
         /** @var string $modelClass */
         $modelClass = $this->argument('model_class');
 
-        if (!in_array(SearchableTrait::class, class_uses($modelClass), true)) {
+        if (!in_array(SearchableTrait::class, class_uses_recursive($modelClass), true)) {
             $this->error('Model not using ' . SearchableTrait::class);
             return;
         }


### PR DESCRIPTION
This PR replaces the php native `class_uses` (which only returns traits used directly a given class) with Laravel‘s `class_uses_recursive` helper (which returns all traits used by a given class, its parent classes and trait of their traits).

This would allow applying the `SearchableTrait` either to a base model or another trait.
